### PR TITLE
Support for arm64 native builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: grafana-agent
-version: '0.36.0'
+version: '0.36.1'
 summary: A telemetry collector for sending metrics, logs, and trace data
 license: Apache-2.0
 contact: simon.aronsson@canonical.com
@@ -44,6 +44,7 @@ apps:
       - proc-sys-kernel-random
 architectures:
   - build-on: amd64
+  - build-on: arm64
 parts:
   wrapper:
     plugin: dump
@@ -55,7 +56,7 @@ parts:
     plugin: go
     source: https://github.com/grafana/agent
     source-type: git
-    source-tag: "v0.36.0"
+    source-tag: "v0.36.1"
     build-snaps:
       - go
     build-packages:


### PR DESCRIPTION
- switched to v0.36.1 to solve "Go 1.21 Support" issue (https://github.com/grafana/godeltaprof/issues/4)
- added arm64 build target (support for native arm64 builds)