### PR TITLE
Build and upload snap for both arm64 and amd64 using remote builds

### DIFF
--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - snap/**
-
+  workflow_dispatch: {}
 
 env:
   SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
@@ -26,10 +26,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install --classic --channel edge snapcraft
+          
+      - name: Build Snap (remote)
+        run: snapcraft remote-build --launchpad-accept-public-upload
 
-      - name: Build Snap
-        run: snapcraft pack --output grafana-agent.snap
+      - name: Upload and Publish amd64 Snap
+        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
 
-      - name: Upload and Publish Snap
-        run: snapcraft upload --release edge grafana-agent.snap
-
+      - name: Upload and Publish arm64 Snap
+        run: snapcraft upload --release edge grafana-agent_*_arm64.snap

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - snap/**
   workflow_dispatch: {}
 
 env:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: grafana-agent
-version: '0.36.0'
+version: '0.39.2'
 summary: A telemetry collector for sending metrics, logs, and trace data
 license: Apache-2.0
 contact: simon.aronsson@canonical.com
@@ -58,7 +58,7 @@ parts:
     plugin: go
     source: https://github.com/grafana/agent
     source-type: git
-    source-tag: "v0.36.0"
+    source-tag: "v0.39.2"
     build-snaps:
       - go
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,8 +42,11 @@ apps:
       - log-observe
       - etc-grafana-agent
       - proc-sys-kernel-random
+
 architectures:
   - build-on: amd64
+  - build-on: arm64
+
 parts:
   wrapper:
     plugin: dump


### PR DESCRIPTION
This PR introduces arm64 as an architecture and makes sure we build for it as well using snapcrafts remote-build functionality. Also adds the ability to trigger rebuilds manually.

resolves #30 
closes #52