### PR TITLE
Enable journald support in promtail

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ parts:
       - bpfcc-tools
     build-environment:
       - USE_CONTAINER: 0
-      - GOFLAGS: "-mod=readonly"
+      - GOFLAGS: "-mod=readonly -tags=promtail_journal_enabled"
     override-build: |
       make agent agentctl
       cp build/grafana-agent $CRAFT_PART_INSTALL/agent


### PR DESCRIPTION
For promtail to be able to ingest journald logs, we need to add the build tag `promtail_journal_enabled`.

resolves #51 
resolves #34 
