### PR TITLE
fix: release-snap.yaml to set snapcraft credentials correctly

### DIFF
--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -37,9 +37,8 @@ jobs:
       - name: Build Snap (remote)
         run: snapcraft remote-build --launchpad-accept-public-upload
 
-      # DEBUG: Temporarily disable these during debugging
-#      - name: Upload and Publish amd64 Snap
-#        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
-#
-#      - name: Upload and Publish arm64 Snap
-#        run: snapcraft upload --release edge grafana-agent_*_arm64.snap
+      - name: Upload and Publish amd64 Snap
+        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
+
+      - name: Upload and Publish arm64 Snap
+        run: snapcraft upload --release edge grafana-agent_*_arm64.snap

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -2,10 +2,8 @@ name: Release Snap
 
 on:
   push:
-    # DEBUG: Remove debugging branch when done
     branches:
       - main
-      - openg-2388
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -36,10 +36,6 @@ jobs:
           git config --global user.email "github-actions@github.com"
           git config --global user.name "Github Actions"
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 120
-
       - name: Build Snap (remote)
         run: snapcraft remote-build --launchpad-accept-public-upload
 

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -29,12 +29,18 @@ jobs:
           mkdir -p ~/.local/share/snapcraft/provider/launchpad
           echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "github-actions@github.com"
-          git config --global user.name "Github Actions"          
+          git config --global user.name "Github Actions"
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 120
+
       - name: Build Snap (remote)
         run: snapcraft remote-build --launchpad-accept-public-upload
 
-      - name: Upload and Publish amd64 Snap
-        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
-
-      - name: Upload and Publish arm64 Snap
-        run: snapcraft upload --release edge grafana-agent_*_arm64.snap
+      # DEBUG: Temporarily disable these during debugging
+#      - name: Upload and Publish amd64 Snap
+#        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
+#
+#      - name: Upload and Publish arm64 Snap
+#        run: snapcraft upload --release edge grafana-agent_*_arm64.snap

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -2,8 +2,10 @@ name: Release Snap
 
 on:
   push:
+    # DEBUG: Remove debugging branch when done
     branches:
       - main
+      - openg-2388
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          # snapcraft remote-build requires a full clone
+          fetch-depth: 0
 
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
@@ -28,8 +31,8 @@ jobs:
         run: |
           sudo snap install --classic --channel edge snapcraft
           # Setup Launchpad credentials
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad
-          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
+          mkdir -p ~/.local/share/snapcraft
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
           git config --global user.email "github-actions@github.com"
           git config --global user.name "Github Actions"
 


### PR DESCRIPTION
Fixes https://github.com/canonical/grafana-agent-snap/issues/62

### Reviewer notes:

pull_request events do not trigger builds in this repo.  To test these changes, [debugging code was added](https://github.com/canonical/grafana-agent-snap/pull/63/files/6af6230cbb9cd494b7a7d44731c251b2b0cc1036) to this PR to temporarily run the CI on the branch.  This CI [succeeded in this run](https://github.com/canonical/grafana-agent-snap/actions/runs/9274416746/job/25516721832?pr=63).  These debug changes have since been removed so we don't merge them into `main`.

### Todo: 
* [x] remove debug code from release-snap.yaml once it is demonstrated passing
* [x] reference the successful CI in this description