### PR TITLE
feat: add test builds of the snap on pull_request events

### DIFF
--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -1,3 +1,7 @@
+# Build and release the snap on merge to main
+#
+# test-build-snap.yaml duplicates some of this workflow's logic.  If modifying this workflow, ensure
+# that test-build-snap.yaml is also updated
 name: Release Snap
 
 on:

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -1,0 +1,36 @@
+# Build the snap on pull_request to ensure the snap is buildable before merge to main
+name: Test Build Snap
+
+on:
+  pull_request:
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+  LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          # snapcraft remote-build requires a full clone
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+      - name: Build Snap (remote)
+        run: snapcraft remote-build --launchpad-accept-public-upload

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -1,4 +1,7 @@
 # Build the snap on pull_request to ensure the snap is buildable before merge to main
+#
+# This workflow duplicates some of the logic from release-snap.yaml.  If modifying this workflow,
+# ensure that release-snap.yaml is also updated
 name: Test Build Snap
 
 on:


### PR DESCRIPTION
Adds test builds to assert the snap is buildable before changes are merged into main.  This will help identify future build failures like when [this change was merged](https://github.com/canonical/grafana-agent-snap/actions/runs/8753095447) before merging to main, and will give [automated builds](https://github.com/canonical/grafana-agent-snap/pull/61) some CI to run against

OPENG-2388