### PR TITLE
Add config option for disabling reporting

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -3,7 +3,7 @@
 DEFAULT_REPORTING_ENABLED="1"
 
 get_reporting_enabled() {
-  value="$(snapctl get reporting_enabled)"
+  value="$(snapctl get reporting-enabled)"
   if [ -z "$value" ]; then
     value="$DEFAULT_REPORTING_ENABLED"
     set_reporting_enabled $value
@@ -12,7 +12,7 @@ get_reporting_enabled() {
 }
 
 set_reporting_enabled() {
-  snapctl set reporting_enabled="$1"
+  snapctl set reporting-enabled="$1"
 }
 
 handle_reporting_enabled() {

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+
+DEFAULT_REPORTING_ENABLED="1"
+
+get_reporting_enabled() {
+  value="$(snapctl get reporting_enabled)"
+  if [ -z "$value" ]; then
+    value="$DEFAULT_REPORTING_ENABLED"
+    set_reporting_enabled $value
+  fi
+  echo "$value"
+}
+
+set_reporting_enabled() {
+  snapctl set reporting_enabled="$1"
+}
+
+handle_reporting_enabled() {
+    reporting_enabled="$(get_reporting_enabled)"
+
+    # Validate
+    if ! expr "$reporting_enabled" : '^[0-1]$' > /dev/null; then
+        echo "\"$reporting_enabled\" must be either 0 (false) or 1 (true)" >&2
+        return 1
+    fi
+    
+    set_reporting_enabled "$reporting_enabled"
+    snapctl restart grafana-agent
+}
+
+handle_reporting_enabled

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,10 +1,10 @@
 #!/bin/sh -e
 
-mkdir -p $SNAP_DATA/etc/
+mkdir -p "${SNAP_DATA}/etc/"
 
-if [ ! -f $SNAP_DATA/etc/grafana-agent.yaml ]
+if [ ! -f "${SNAP_DATA}/etc/grafana-agent.yaml" ]
 then
-  cat <<EOF > $SNAP_DATA/etc/grafana-agent.yaml
+  cat <<EOF > "${SNAP_DATA}/etc/grafana-agent.yaml"
 integrations:
   agent:
     enabled: true
@@ -12,4 +12,3 @@ integrations:
     enabled: true
 EOF
 fi
-

--- a/snap/local/agent-wrapper
+++ b/snap/local/agent-wrapper
@@ -5,8 +5,17 @@ IS_CONNECTED=$(snapctl is-connected etc-grafana-agent; echo $?)
 if [ "${IS_CONNECTED}" = "0" -a -r /etc/grafana-agent.yaml ]
 then
   echo "Launched with config from the host filesystem" | systemd-cat
-  exec "${SNAP}/agent" -config.expand-env -config.file "/etc/grafana-agent.yaml"
+  CONFIG_FILE="/etc/grafana-agent.yaml"
 else
   echo "Launched with minimal default config from the snap" | systemd-cat
-  exec "${SNAP}/agent" -config.expand-env -config.file "$SNAP_DATA/etc/grafana-agent.yaml"
+  CONFIG_FILE="$SNAP_DATA/etc/grafana-agent.yaml"
 fi
+
+if [ "$(snapctl get reporting_enabled)" = "0" ]
+then
+  REPORTING_ARG="-disable-reporting"
+else
+  REPORTING_ARG=""
+fi
+
+exec "${SNAP}/agent" -config.expand-env -config.file "${CONFIG_FILE}" "${REPORTING_ARG}"

--- a/snap/local/agent-wrapper
+++ b/snap/local/agent-wrapper
@@ -11,10 +11,12 @@ else
   CONFIG_FILE="$SNAP_DATA/etc/grafana-agent.yaml"
 fi
 
-if [ "$(snapctl get reporting_enabled)" = "0" ]
+if [ "$(snapctl get reporting-enabled)" = "0" ]
 then
+  echo "Launched with reporting disabled" | systemd-cat
   REPORTING_ARG="-disable-reporting"
 else
+  echo "Launched with reporting enabled" | systemd-cat
   REPORTING_ARG=""
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,7 +58,7 @@ parts:
     source-type: git
     source-tag: "v0.40.4"
     build-snaps:
-      - go
+      - go/1.22/stable
     build-packages:
       - build-essential
       - libsystemd-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,10 +43,8 @@ apps:
       - etc-grafana-agent
       - proc-sys-kernel-random
 architectures:
-  - build-on: [amd64]
-  - build-on: [amd64, arm64]
-    build-for: [arm64]
-
+  - build-on: amd64
+  - build-on: arm64
 parts:
   wrapper:
     plugin: dump
@@ -66,18 +64,6 @@ parts:
       - libsystemd-dev
       - libbpfcc-dev
       - bpfcc-tools
-      - on amd64 to arm64:
-        - gcc-aarch64-linux-gnu
-        - linux-libc-dev-arm64-cross
-        - libc6-dev-arm64-cross
-    build-environment:
-      - to amd64:
-        - GOOS: linux
-        - GOARCH: amd64
-      - to arm64:
-        - GOOS: linux
-        - GOARCH: arm64
-        - CC: /usr/bin/aarch64-linux-gnu-gcc
     stage-packages:
       - libsystemd0
       - libbpfcc


### PR DESCRIPTION
## Issue
By default, grafana-agent [sends out anonymous usage stats](https://grafana.com/docs/agent/latest/static/configuration/flags/#report-information-usage). This may be undesired in hardened environments.


## Solution
Add a snap config option to disable the reporting ([ref](https://grafana.com/docs/agent/latest/static/configuration/flags/#report-information-usage)). The config option is named the same way as in the grafana-k8s charm (see [grafana/354](https://github.com/canonical/grafana-k8s-operator/pull/354)).

In tandem with:
- https://github.com/canonical/grafana-agent-operator/pull/202

Related:
- https://github.com/canonical/grafana-agent-k8s-operator/pull/326
- https://github.com/canonical/grafana-k8s-operator/pull/354


## Context
- [ADR](https://github.com/canonical/observability/blob/085a923571a3117437be1abb49136c26ac88f567/decision-records/2024-06-27--upstream-telemetry.md)