### PR TITLE
Split strict, classic CI

### DIFF
--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -15,7 +15,43 @@ env:
   LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
 
 jobs:
-  build:
+  build-strict:
+    name: Build snap (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          # snapcraft remote-build requires a full clone
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+      - name: Build Snap (remote)
+        run: snapcraft remote-build --launchpad-accept-public-upload
+
+      - name: Upload and Publish amd64 Snap
+        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
+
+      - name: Upload and Publish arm64 Snap
+        run: snapcraft upload --release edge grafana-agent_*_arm64.snap
+
+  build-classic:
+    name: Build snap (classic)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -42,15 +78,6 @@ jobs:
 
       - name: yq - portable yaml processor
         uses: mikefarah/yq@v4
-
-      - name: Build Snap (remote)
-        run: snapcraft remote-build --launchpad-accept-public-upload
-
-      - name: Upload and Publish amd64 Snap
-        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
-
-      - name: Upload and Publish arm64 Snap
-        run: snapcraft upload --release edge grafana-agent_*_arm64.snap
 
       - name: Convert to Classic Snap
         run: ./make-classic.sh

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    name: Build snap (strict)
+    name: Build snap (${{ matrix.confinement }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -15,44 +15,18 @@ env:
   LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
 
 jobs:
-  build-strict:
+  build:
     name: Build snap (strict)
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          # snapcraft remote-build requires a full clone
-          fetch-depth: 0
-
-      - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
-        with:
-          channel: latest/stable
-
-      - name: Install dependencies
-        run: |
-          sudo snap install --classic --channel edge snapcraft
-          # Setup Launchpad credentials
-          mkdir -p ~/.local/share/snapcraft
-          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad
-          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "Github Actions"
-
-      - name: Build Snap (remote)
-        run: snapcraft remote-build --launchpad-accept-public-upload
-
-      - name: Upload and Publish amd64 Snap
-        run: snapcraft upload --release edge grafana-agent_*_amd64.snap
-
-      - name: Upload and Publish arm64 Snap
-        run: snapcraft upload --release edge grafana-agent_*_arm64.snap
-
-  build-classic:
-    name: Build snap (classic)
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        confinement: [ "strict", "classic" ]
+        include:
+          - confinement: "strict"
+            channel: "latest/edge"
+          - confinement: "classic"
+            channel: "0.40-classic/edge"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -79,14 +53,15 @@ jobs:
       - name: yq - portable yaml processor
         uses: mikefarah/yq@v4
 
-      - name: Convert to Classic Snap
+      - if: ${{ matrix.confinement == 'classic' }}
+        name: Convert to Classic Snap
         run: ./make-classic.sh
 
-      - name: Build Classic Snap (remote)
+      - name: Build Snap (remote)
         run: snapcraft remote-build --launchpad-accept-public-upload
 
-      - name: Upload and Publish Classic amd64 Snap
-        run: snapcraft upload --release 0.40-classic/edge grafana-agent_*_amd64.snap
+      - name: Upload and Publish amd64 Snap
+        run: snapcraft upload --release ${{ matrix.channel }} grafana-agent_*_amd64.snap
 
-      - name: Upload and Publish Classic arm64 Snap
-        run: snapcraft upload --release 0.40-classic/edge grafana-agent_*_arm64.snap
+      - name: Upload and Publish arm64 Snap
+        run: snapcraft upload --release ${{ matrix.channel }} grafana-agent_*_arm64.snap

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Build snap (strict)
+    name: Build snap (${{ matrix.confinement }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -13,7 +13,12 @@ env:
 
 jobs:
   build:
+    name: Build snap (strict)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        confinement: [ "strict", "classic" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -34,6 +39,13 @@ jobs:
           echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
           git config --global user.email "github-actions@github.com"
           git config --global user.name "Github Actions"
+
+      - name: yq - portable yaml processor
+        uses: mikefarah/yq@v4
+
+      - if: ${{ matrix.confinement == 'classic' }}
+        name: Convert to Classic Snap
+        run: ./make-classic.sh
 
       - name: Build Snap (remote)
         run: snapcraft remote-build --launchpad-accept-public-upload

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ license: Apache-2.0
 contact: simon.aronsson@canonical.com
 issues: https://github.com/canonical/grafana-agent-snap/issues
 source-code: https://github.com/canonical/grafana-agent-snap
-website: https://grafana.com
+website: https://grafana.com/oss/agent/
 description: "Grafana Agent is a telemetry collector for sending metrics, \nlogs, and trace data to the opinionated Grafana observability stack.\n"
 base: core22
 grade: stable


### PR DESCRIPTION
## Problem
CI failed to build/release the classic snap:
https://github.com/canonical/grafana-agent-snap/actions/runs/11918322526/attempts/1

When retried, the strict also failed:
https://github.com/canonical/grafana-agent-snap/actions/runs/11918322526/job/33218128231

When attempting a remote-build from my machine, it fails with:
```
git_ref: No such object "/~sed-i/sed-i-craft-remote-build/+git/snapcraft-grafana-agent-360bed9ebd3fa769727a08d3c7df86ae/+ref/main".
```

We should be able to retry the strict or classic build separately.

## Solution
Separate the build into independent jobs.

Drive-by:
- Update the website metadata field. This could also help with the store potentially rejecting the next upload for trying to upload the exact same object again. 