### PR TITLE
add home plug to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,7 @@ apps:
       - log-observe
       - etc-grafana-agent
       - proc-sys-kernel-random
+      - home
 architectures:
   - build-on: amd64
   - build-on: arm64


### PR DESCRIPTION
The `log-observe` interface [does not support `dac_read_search` capability](https://bugs.launchpad.net/snapd/+bug/2098780).

It only [supports `dac_override` capability](https://github.com/canonical/snapd/blob/master/interfaces/builtin/log_observe.go#L74), and because of that, the `strict` confinement snap [produces excessive amount of logs in audit.log on a CIS-hardened systems](https://github.com/canonical/grafana-agent-operator/issues/52).
On the other hand, the [`home` interface does support `dac_read_search`](https://github.com/canonical/snapd/blob/master/interfaces/builtin/home.go#L91).

We add the `home` plug with the hope this workaround won't produce excessive amount of logs because of the `dac_read_search` capability enabled.

