### PR TITLE
Add support for TLS config

### DIFF
--- a/snap/local/agent-wrapper
+++ b/snap/local/agent-wrapper
@@ -10,17 +10,40 @@ else
   REPORTING_ARG=""
 fi
 
+get_tls_args() {
+  # $1 = path to config file
+  
+  http_tls=$(yq '.server.http_tls_config.key_file and .server.http_tls_config.cert_file' "$1")
+  grpc_tls=$(yq '.server.grpc_tls_config.key_file and .server.grpc_tls_config.cert_file' "$1")
+
+  tls_args=""
+  if [ "$http_tls" = true ]; then
+    tls_args="-server.http.enable-tls"
+  fi
+  if [ "$grpc_tls" = true ]; then
+    tls_args="${tls_args} -server.grpc.enable-tls"
+  fi
+
+  echo "$tls_args"
+}
 
 launch_classic() {
-
+  # $1 = path to config file
+  
   echo "Launching with config from the host filesystem" | systemd-cat
-  exec "${SNAP}/agent" -config.expand-env -config.file "/etc/grafana-agent.yaml" "${REPORTING_ARG}"  
+  exec "${SNAP}/agent" -config.expand-env -config.file "$1" "${REPORTING_ARG}" "$(get_tls_args "$1")" 
 
 }
 
 
 launch_strict() {
-  
+  # $1 = path to config file
+
+  exec "${SNAP}/agent" -config.expand-env -config.file "$1" "${REPORTING_ARG}" "$(get_tls_args "$1")"
+
+}
+
+get_strict_config_path() {
   IS_CONNECTED=$(snapctl is-connected etc-grafana-agent; echo $?)
 
   if [ "${IS_CONNECTED}" = "0" ] && [ -r /etc/grafana-agent.yaml ]
@@ -32,17 +55,15 @@ launch_strict() {
     CONFIG_FILE="$SNAP_DATA/etc/grafana-agent.yaml"
   fi
 
-  exec "${SNAP}/agent" -config.expand-env -config.file "${CONFIG_FILE}" "${REPORTING_ARG}"
-
+  echo "$CONFIG_FILE"
 }
-
 
 # Detect confinement type
 # https://forum.snapcraft.io/t/reliable-way-of-detecting-snap-confinement-mode/8896/4
 IS_CLASSIC=$(grep -qxF "confinement: classic" "$SNAP/meta/snap.yaml"; echo $?)
 if [ "${IS_CLASSIC}" = "0" ]
 then
-  launch_classic
+  launch_classic "/etc/grafana-agent.yaml"
 else
-  launch_strict
+  launch_strict "$(get_strict_config_path)"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,8 @@ parts:
     source-tag: "v0.40.4"
     build-snaps:
       - go/1.22/stable
+    stage-snaps:
+      - yq/v4/stable
     build-packages:
       - build-essential
       - libsystemd-dev


### PR DESCRIPTION
This PR add logic to the wrapper script to add args when the appropriate section is present in the config file, and includes both private key and a server cert.

- Add `-server.http.enable-tls` arg, when the `server. http_tls_config` section is defined.
- Add `server.grpc_tls_config` arg, when the `server.grpc_tls_config` section is defined.

This is needed to be able to form TLS with grafana-agent is the server side (e.g. push into grafana-agent).